### PR TITLE
Make 'caller' and 'target' attributes optional in the base event

### DIFF
--- a/events/base_event.json
+++ b/events/base_event.json
@@ -5,11 +5,11 @@
   "attributes": {
     "caller": {
       "group": "context",
-      "requirement": "required"
+      "requirement": "optional"
     },
     "target": {
       "group": "context",
-      "requirement": "required"
+      "requirement": "optional"
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Michael Radka <mradka@splunk.com>