### PR TITLE
SESA-1170: Adding associations and observable type

### DIFF
--- a/events/network/tunnel_activity.json
+++ b/events/network/tunnel_activity.json
@@ -68,5 +68,13 @@
       "group": "primary",
       "requirement": "recommended"
     }
+  },
+  "associations": {
+    "user": [
+      "tunnel_interface"
+    ],
+    "tunnel_interface": [
+      "user"
+    ]
   }
 }

--- a/objects/network_interface_ex.json
+++ b/objects/network_interface_ex.json
@@ -1,6 +1,7 @@
 {
   "description": "The extended/enriched network_interface object.",
   "extends": "network_interface",
+  "observable": 100000,
   "attributes": {
     "type_id": {
       "description": "The network interface type identifier.",

--- a/objects/network_interface_ex.json
+++ b/objects/network_interface_ex.json
@@ -1,7 +1,6 @@
 {
   "description": "The extended/enriched network_interface object.",
   "extends": "network_interface",
-  "observable": 100000,
   "attributes": {
     "type_id": {
       "description": "The network interface type identifier.",


### PR DESCRIPTION
# Context
~~We need to add a new observable type for the Network Interface object~~. In addition, we want to associate the `user` with the `tunnel_interface` -> We are just updating the associations for now as the original proposed changes to the network_interface object are not possible for the current implementation of the ocsf-server.

# Code Changes
* ~~Added observable ID 100000 to Network Interface object~~
* Added `user -> tunnel_interface` and `tunnel_interface -> user` associations to Network Tunnel Activity class

# Testing
* Ran a local OCSF server and observed my changes (associations at the bottom of the Network Tunnel Activity class)
<img width="894" alt="Screenshot 2024-04-02 at 11 07 12 AM" src="https://github.com/ocsf/splunk/assets/127444568/cf8c146d-7841-4829-9c2b-65de88ad919e">
