### PR TITLE
SESA-1170: Associating user and client_interface

### DIFF
--- a/events/network/tunnel_activity.json
+++ b/events/network/tunnel_activity.json
@@ -68,5 +68,13 @@
       "group": "primary",
       "requirement": "recommended"
     }
+  },
+  "associations": {
+    "user": [
+      "client_interface"
+    ],
+    "client_interface": [
+      "user"
+    ]
   }
 }


### PR DESCRIPTION
# Context
We want to associate the `user` with the `client_interface`

# Code Changes
* Added `user -> client_interface` and `client_interface -> user` associations to Network Tunnel Activity class

# Testing
* Ran a local OCSF server and observed my changes (associations at the bottom of the Network Tunnel Activity class)

<img width="397" alt="Screenshot 2024-04-05 at 8 22 21 AM" src="https://github.com/ocsf/splunk/assets/127444568/b876d437-ce6c-443e-a22f-fa961a85e4be">
