### PR TITLE
Update tunnel class name, roll version

### DIFF
--- a/events/network/tunnel_activity.json
+++ b/events/network/tunnel_activity.json
@@ -1,9 +1,9 @@
 {
-  "caption": "Network Tunnel Activity",
+  "caption": "Tunnel Activity",
   "description": "Tunnel Activity events report secure tunnel establishment, teardowns, renewals, and other network tunnel specific actions.",
   "category": "network",
   "extends": "base_event",
-  "name": "network_tunnel_activity",
+  "name": "tunnel_activity",
   "uid": 11,
   "attributes": {
     "activity_id": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "uid": 1
 }


### PR DESCRIPTION
Updates the class name from "Network Tunnel Activity" to "Tunnel Activity" to match the `OCSF 1.2.0` class name.

Impact: `class_name` value will now be `Tunnel Activity` when using the extension starting with Splunk extension version `v1.1.0`.

<img width="564" alt="image" src="https://github.com/ocsf/splunk/assets/91983279/67b769ae-ff92-4052-8417-8443d15f6bd4">
