### PR TITLE
SESA-1232 Add Event Log Activity Class

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -48,6 +48,35 @@
       "description": "The logging provider or logging service that logged the event. For example, Microsoft-Windows-Security-Auditing.",
       "type": "string_t"
     },
+    "log_type": {
+      "caption": "Log Type",
+      "description": "The log type, normalized to the caption of the <code>log_type_id</code> value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "log_type_id": {
+      "caption": "Log Type ID",
+      "description": "The normalized log type identifier.",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The log type is unknown."
+        },
+        "1": {
+          "caption": "OS",
+          "description": "The log type is an Operating System log."
+        },
+        "2": {
+          "caption": "Application",
+          "description": "The log type is an Application log."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The log type is not mapped. See the <code>log_type</code> attribute, which contains a data source specific value."
+        }
+      },
+      "sibling": "log_type",
+      "type": "integer_t"
+    },
     "log_version": {
       "caption": "Log Version",
       "description": "The event log schema version that specifies the format of the original event. For example syslog version or Cisco Log Schema Version.",

--- a/events/system/event_log.json
+++ b/events/system/event_log.json
@@ -1,0 +1,117 @@
+{
+  "caption": "Event Log Activity",
+  "description": "Event Log Activity events report actions pertaining to the system's event logging service(s), such as disabling logging or clearing the log data.",
+  "extends": "system",
+  "name": "event_log",
+  "uid": 2,
+  "attributes": {
+    "activity_id": {
+      "enum": {
+        "1": {
+          "caption": "Clear",
+          "description": "Clear the event log database, file, or cache."
+        },
+        "2": {
+          "caption": "Delete",
+          "description": "Delete the event log database, file, or cache."
+        },
+        "3": {
+          "caption": "Export",
+          "description": "Export the event log database, file, or cache."
+        },
+        "4": {
+          "caption": "Archive",
+          "description": "Archive the event log database, file, or cache."
+        },
+        "5": {
+          "caption": "Rotate",
+          "description": "Rotate the event log database, file, or cache."
+        },
+        "6": {
+          "caption": "Start",
+          "description": "Start the event logging service."
+        },
+        "7": {
+          "caption": "Stop",
+          "description": "Stop the event logging service."
+        },
+        "8": {
+          "caption": "Restart",
+          "description": "Restart the event logging service."
+        },
+        "9": {
+          "caption": "Enable",
+          "description": "Enable the event logging service."
+        },
+        "10": {
+          "caption": "Disable",
+          "description": "Disable the event logging service."
+        }
+      }
+    },
+    "actor": {
+      "description": "The actor that performed the activity.",
+      "group": "primary",
+      "profile": null,
+      "requirement": "recommended"
+    },
+    "device": {
+      "description": "The device that reported the event.",
+      "group": "primary",
+      "profile": null,
+      "requirement": "recommended"
+    },
+    "dst_endpoint": {
+      "description": "The <p style='display:inline;color:red'>targeted</p> endpoint for the event log activity.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "file": {
+      "description": "The file <p style='display:inline;color:red'>targeted by</p> the activity. Example: <code>/var/log/audit.log</code>",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "log_name": {
+      "description": "The name of the event log <p style='display:inline;color:red'>targeted by</p> the activity. Example: Windows <code>Security</code>.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "log_provider": {
+      "description": "The logging provider or logging service <p style='display:inline;color:red'>targeted by</p> the activity.<br />Example: <code>Microsoft-Windows-Security-Auditing</code>, <code>Auditd</code>, or <code>Syslog</code>.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "log_type": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "log_type_id": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "src_endpoint": {
+      "description": "The source endpoint for the event log activity.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "status_code": {
+      "description": "The event status code, as reported by the event source.<br />Example: <code>0</code>, <code>8</code>, or <code>21</code> for <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/desktop/eventlogprov/cleareventlog-method-in-class-win32-nteventlogfile'>Windows ClearEventLog</a>.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "status_detail": {
+      "description": "The status detail contains additional information about the event outcome.<br />Example: <code>Success</code>, <code>Privilege Missing</code>, or <code>Invalid Parameter</code> for <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/desktop/eventlogprov/cleareventlog-method-in-class-win32-nteventlogfile'>Windows ClearEventLog</a>.",
+      "group": "primary",
+      "requirement": "recommended"
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+      "log_file",
+      "log_name",
+      "log_provider",
+      "log_type",
+      "log_type_id"
+    ]
+  }
+}

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "uid": 1
 }


### PR DESCRIPTION
This PR Adds the new `Event Log Activity` [class](https://schema.ocsf.io/1.3.0-dev/classes/event_log?extensions=) as it was introduced in OCSF `v1.3` for mapping events such as Windows Security `1102`:

<img width="217" alt="image" src="https://github.com/ocsf/splunk/assets/91983279/ef9ee5a8-e31d-4ec9-acad-e0956910ed66">

<img width="1226" alt="image" src="https://github.com/ocsf/splunk/assets/91983279/766902b5-3cd2-45d6-8375-f12e8fc79f16">

Related OCSF Core PR: https://github.com/ocsf/ocsf-schema/pull/1014 

NOTE: As with all ports of a Core class to an Extension class, the `class_uid` and resulting `type_uid` are different.
