### PR TITLE
SESA-1244 Add src_endpoint to Entity Mgmt

### DIFF
--- a/events/audit/entity.json
+++ b/events/audit/entity.json
@@ -1,0 +1,14 @@
+{
+  "description": "The extended Entity Management class.",
+  "extends": "entity_management",
+  "profiles": [
+    "splunk/ba"
+  ],
+  "attributes": {
+    "src_endpoint": {
+      "description": "Details about the source of the IAM activity.",
+      "group": "primary",
+      "requirement": "recommended"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the `src_endpoint` attribute to the `Entity Management` class, which is present in 1.2 and greater versions of OCSF but not in RC2:

<img width="692" alt="image" src="https://github.com/ocsf/splunk/assets/91983279/824f628c-2124-4518-a0bf-651fb23e3f37">
