### PR TITLE
Enhance the entity management class

### DIFF
--- a/events/audit/entity.json
+++ b/events/audit/entity.json
@@ -5,6 +5,79 @@
     "splunk/ba"
   ],
   "attributes": {
+    "activity_id": {
+      "enum": {
+        "1": {
+          "caption": "Create",
+          "description": "Create a new managed entity."
+        },
+        "2": {
+          "caption": "Read",
+          "description": "Read an existing managed entity."
+        },
+        "3": {
+          "caption": "Update",
+          "description": "Update an existing managed entity."
+        },
+        "4": {
+          "caption": "Delete",
+          "description": "Delete a managed entity."
+        },
+        "5": {
+          "caption": "Move",
+          "description": "Move or rename an existing managed entity."
+        },
+        "6": {
+          "caption": "Enroll",
+          "description": "Enroll an existing managed entity."
+        },
+        "7": {
+          "caption": "Unenroll",
+          "description": "Unenroll an existing managed entity."
+        },
+        "8": {
+          "caption": "Enable",
+          "description": "Enable an existing managed entity. Note: This is typically regarded as a semi-permanent, editor visible, syncable change."
+        },
+        "9": {
+          "caption": "Disable",
+          "description": "Disable an existing managed entity. Note: This is typically regarded as a semi-permanent, editor visible, syncable change."
+        },
+        "10": {
+          "caption": "Activate",
+          "description": "Activate an existing managed entity. Note: This is a typically regarded as a transient change, a change of state of the engine."
+        },
+        "11": {
+          "caption": "Deactivate",
+          "description": "Deactivate an existing managed entity. Note: This is a typically regarded as a transient change, a change of state of the engine."
+        },
+        "12": {
+          "caption": "Suspend",
+          "description": "Suspend an existing managed entity."
+        },
+        "13": {
+          "caption": "Resume",
+          "description": "Resume (unsuspend) an existing managed entity."
+        }
+      }
+    },
+    "actor": {
+      "description": "Use for when the entity acting upon another entity is a process or user.",
+      "group": "context"
+    },
+    "comment": {
+      "description": "The user provided comment about why the entity was changed.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "entity": {
+      "group": "primary",
+      "requirement": "required"
+    },
+    "entity_result": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
     "src_endpoint": {
       "description": "Details about the source of the IAM activity.",
       "group": "primary",

--- a/events/audit/entity.json
+++ b/events/audit/entity.json
@@ -62,7 +62,7 @@
       }
     },
     "actor": {
-      "description": "Use for when the entity acting upon another entity is a process or user.",
+      "description": "Used for when the entity acting upon another entity is a process or user.",
       "group": "context"
     },
     "comment": {

--- a/objects/managed_entity_ex.json
+++ b/objects/managed_entity_ex.json
@@ -1,0 +1,87 @@
+{
+  "caption": "Managed Entity",
+  "description": "The Managed Entity object describes the type and version of an entity, such as a user, device, or policy.  For types in the <code>type_id</code> enum list, an associated attribute should be populated.  If the type of entity is not in the <code>type_id</code> list, information can be put into the <code>data</code> attribute and the <code>type</code> attribute should identify the entity.",
+  "extends": "managed_entity",
+  "name": "managed_entity",
+  "attributes": {
+    "data": {
+      "description": "The managed entity content as a JSON object.",
+      "requirement": "optional"
+    },
+    "name": {
+      "description": "The name of the managed entity.",
+      "requirement": "recommended"
+    },
+    "type": {
+      "description": "The managed entity type. For example: <code>policy</code>, <code>user</code>, <code>organizational unit</code>, <code>device</code>.",
+      "requirement": "recommended"
+    },
+    "type_id": {
+      "requirement": "recommended",
+      "description": "The type of the Managed Entity. It is recommended to also populate the <code>type</code> attribute with the associated label, or the source specific name if <code>Other</code>.",
+      "enum": {
+        "1": {
+          "caption": "Device",
+          "description": "A managed Device entity.  This item corresponds to population of the <code>device</code> attribute."
+        },
+        "2": {
+          "caption": "User",
+          "description": "A managed User entity.  This item corresponds to population of the <code>user</code> attribute."
+        },
+        "3": {
+          "caption": "Group",
+          "description": "A managed Group entity.  This item corresponds to population of the <code>group</code> attribute."
+        },
+        "4": {
+          "caption": "Organization",
+          "description": "A managed Organization entity.  This item corresponds to population of the <code>org</code> attribute."
+        },
+        "5": {
+          "caption": "Policy",
+          "description": "A managed Policy entity.  This item corresponds to population of the <code>policy</code> attribute."
+        },
+        "6": {
+          "caption": "Email",
+          "description": "A managed Email entity.  This item corresponds to population of the <code>email</code> attribute."
+        }
+      }
+    },
+    "device": {
+      "requirement": "recommended"
+    },
+    "email": {
+      "requirement": "recommended"
+    },
+    "group": {
+      "requirement": "recommended"
+    },
+    "org": {
+      "requirement": "recommended"
+    },
+    "policy": {
+      "requirement": "recommended",
+      "description": "Describes details of a managed policy."
+    },
+    "uid": {
+      "description": "The identifier of the managed entity."
+    },
+    "user": {
+      "requirement": "recommended"
+    },
+    "version": {
+      "description": "The version of the managed entity. For example: <code>1.2.3</code>.",
+      "requirement": "recommended"
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+      "name",
+      "uid",  
+      "device",
+      "group",
+      "org",
+      "policy",
+      "user"
+    ]
+  }
+}


### PR DESCRIPTION
This PR ports the OCSF Core enhancements to the `Entity Management` class:

- Adds new activity_id's to the class
- Adds `type_id` to the `managed_entity` object, along with `device` and `email` attributes.

Reference Core PRs:
- https://github.com/ocsf/ocsf-schema/pull/1095
- https://github.com/ocsf/ocsf-schema/pull/1094

<img width="1242" alt="image" src="https://github.com/ocsf/splunk/assets/91983279/2652e21e-ccdc-41a0-adc3-e8a174a14fe8">

<img width="1264" alt="image" src="https://github.com/ocsf/splunk/assets/91983279/7308f7a2-ec79-4dd3-b7b2-89c7413d88da">
