### PR TITLE
Adding missing attributes, adding analytic object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3,6 +3,27 @@
   "description": "The Attribute Dictionary defines schema attributes and includes references to the events and objects in which they are used.",
   "name": "dictionary",
   "attributes": {
+    "analytic": {
+      "caption": "Analytic",
+      "description": "The analytic technique used to analyze and derive insights from the data or information that led to the finding or conclusion.",
+      "type": "analytic"
+    },
+    "analytic_stories": {
+      "caption": "Analytic Stories",
+      "description": "The analytic stories associated with the detection.",
+      "is_array": true,
+      "type": "string_t"
+    },
+    "caller": {
+      "caption": "Caller",
+      "description": "The point of origin from which the action was directed. Its values are derived via business logic. This usually represents the inferred source entity for a logon.",
+      "type": "inference"
+    },
+    "category": {
+      "caption": "Category",
+      "description": "The object category. See specific usage.",
+      "type": "string_t"
+    },
     "client_interface": {
       "caption": "Client Interface",
       "description": "The client interface. See specific usage.",
@@ -22,103 +43,6 @@
       "description": "A two-element array, containing a longitude/latitude pair. The format conforms with <a target='_blank' href='https://geojson.org'>GeoJSON</a>. For example: <code>[-73.983, 40.719]</code>.",
       "is_array": true,
       "type": "float_t"
-    },
-    "event_code": {
-      "caption": "Event Code",
-      "description": "The Event ID or Code that the product uses to describe the event.",
-      "type": "string_t"
-    },
-    "evidences": {
-      "caption": "Evidence Artifacts",
-      "description": "Describes various evidence artifacts associated to the activity/activities that triggered a security detection.",
-      "type": "evidences",
-      "is_array": true
-    },
-    "finding_info": {
-      "caption": "Finding Information",
-      "description": "Describes the supporting information about a generated finding.",
-      "type": "finding_info"
-    },
-    "geohash": {
-      "caption": "Geohash",
-      "description": "<p>Geohash of the geo-coordinates (latitude and longitude).</p><a target='_blank' href='https://en.wikipedia.org/wiki/Geohash'>Geohashing</a> is a geocoding system used to encode geographic coordinates in decimal degrees, to a single string.",
-      "type": "string_t"
-    },
-    "lat": {
-      "caption": "Latitude",
-      "description": "The geographical Latitude coordinate represented in Decimal Degrees (DD). For example: <code>42.361145</code>.",
-      "type": "float_t"
-    },
-    "log_level": {
-      "caption": "Log Level",
-      "description": "The audit level at which an event was generated.",
-      "type": "string_t"
-    },
-    "log_name": {
-      "caption": "Log Name",
-      "description": "The event log name. For example, syslog file name or Windows logging subsystem: Security.",
-      "type": "string_t"
-    },
-    "log_provider": {
-      "caption": "Log Provider",
-      "description": "The logging provider or logging service that logged the event. For example, Microsoft-Windows-Security-Auditing.",
-      "type": "string_t"
-    },
-    "log_type": {
-      "caption": "Log Type",
-      "description": "The log type, normalized to the caption of the <code>log_type_id</code> value. In the case of 'Other', it is defined by the event source.",
-      "type": "string_t"
-    },
-    "log_type_id": {
-      "caption": "Log Type ID",
-      "description": "The normalized log type identifier.",
-      "enum": {
-        "0": {
-          "caption": "Unknown",
-          "description": "The log type is unknown."
-        },
-        "1": {
-          "caption": "OS",
-          "description": "The log type is an Operating System log."
-        },
-        "2": {
-          "caption": "Application",
-          "description": "The log type is an Application log."
-        },
-        "99": {
-          "caption": "Other",
-          "description": "The log type is not mapped. See the <code>log_type</code> attribute, which contains a data source specific value."
-        }
-      },
-      "sibling": "log_type",
-      "type": "integer_t"
-    },
-    "log_version": {
-      "caption": "Log Version",
-      "description": "The event log schema version that specifies the format of the original event. For example syslog version or Cisco Log Schema Version.",
-      "type": "string_t"
-    },
-    "loggers": {
-      "caption": "Loggers",
-      "description": "An array of Logger objects that describe the devices and logging products between the event source and its eventual destination. Note, this attribute can be used when there is a complex end-to-end path of event flow.",
-      "is_array": true,
-      "type": "logger"
-    },
-    "long": {
-      "caption": "Longitude",
-      "description": "The geographical Longitude coordinate represented in Decimal Degrees (DD). For example: <code>-71.057083</code>.",
-      "type": "float_t"
-    },
-    "analytic_stories": {
-      "caption": "Analytic Stories",
-      "description": "The analytic stories associated with the detection.",
-      "is_array": true,
-      "type": "string_t"
-    },
-    "caller": {
-      "caption": "Caller",
-      "description": "The point of origin from which the action was directed. Its values are derived via business logic. This usually represents the inferred source entity for a logon.",
-      "type": "inference"
     },
     "cis_csc": {
       "caption": "CIS CSC",
@@ -178,14 +102,35 @@
       "description": "The end date of a user's employment.",
       "type": "timestamp_t"
     },
+    "event_code": {
+      "caption": "Event Code",
+      "description": "The Event ID or Code that the product uses to describe the event.",
+      "type": "string_t"
+    },
     "evidence": {
       "caption": "Evidence",
       "description": "The data the detection exposes to the analyst.",
       "type": "json_t"
     },
+    "evidences": {
+      "caption": "Evidence Artifacts",
+      "description": "Describes various evidence artifacts associated to the activity/activities that triggered a security detection.",
+      "type": "evidences",
+      "is_array": true
+    },
+    "finding_info": {
+      "caption": "Finding Information",
+      "description": "Describes the supporting information about a generated finding.",
+      "type": "finding_info"
+    },
     "full_name": {
       "caption": "Full Name",
       "description": "The user's full name.",
+      "type": "string_t"
+    },
+    "geohash": {
+      "caption": "Geohash",
+      "description": "<p>Geohash of the geo-coordinates (latitude and longitude).</p><a target='_blank' href='https://en.wikipedia.org/wiki/Geohash'>Geohashing</a> is a geocoding system used to encode geographic coordinates in decimal degrees, to a single string.",
       "type": "string_t"
     },
     "home_folder": {
@@ -259,6 +204,71 @@
       "description": "The <a target='_blank' href='https://www.lockheedmartin.com/en-us/capabilities/cyber/cyber-kill-chain.html'>Cyber Kill Chain®</a>.",
       "is_array": true,
       "type": "kill_chain"
+    },
+    "lat": {
+      "caption": "Latitude",
+      "description": "The geographical Latitude coordinate represented in Decimal Degrees (DD). For example: <code>42.361145</code>.",
+      "type": "float_t"
+    },
+    "log_level": {
+      "caption": "Log Level",
+      "description": "The audit level at which an event was generated.",
+      "type": "string_t"
+    },
+    "log_name": {
+      "caption": "Log Name",
+      "description": "The event log name. For example, syslog file name or Windows logging subsystem: Security.",
+      "type": "string_t"
+    },
+    "log_provider": {
+      "caption": "Log Provider",
+      "description": "The logging provider or logging service that logged the event. For example, Microsoft-Windows-Security-Auditing.",
+      "type": "string_t"
+    },
+    "log_type": {
+      "caption": "Log Type",
+      "description": "The log type, normalized to the caption of the <code>log_type_id</code> value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "log_type_id": {
+      "caption": "Log Type ID",
+      "description": "The normalized log type identifier.",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The log type is unknown."
+        },
+        "1": {
+          "caption": "OS",
+          "description": "The log type is an Operating System log."
+        },
+        "2": {
+          "caption": "Application",
+          "description": "The log type is an Application log."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The log type is not mapped. See the <code>log_type</code> attribute, which contains a data source specific value."
+        }
+      },
+      "sibling": "log_type",
+      "type": "integer_t"
+    },
+    "log_version": {
+      "caption": "Log Version",
+      "description": "The event log schema version that specifies the format of the original event. For example syslog version or Cisco Log Schema Version.",
+      "type": "string_t"
+    },
+    "loggers": {
+      "caption": "Loggers",
+      "description": "An array of Logger objects that describe the devices and logging products between the event source and its eventual destination. Note, this attribute can be used when there is a complex end-to-end path of event flow.",
+      "is_array": true,
+      "type": "logger"
+    },
+    "long": {
+      "caption": "Longitude",
+      "description": "The geographical Longitude coordinate represented in Decimal Degrees (DD). For example: <code>-71.057083</code>.",
+      "type": "float_t"
     },
     "macs": {
       "caption": "MAC List",
@@ -359,6 +369,12 @@
       "caption": "Public IP",
       "description": "The public IP address of an endpoint or a device.",
       "type": "ip_t"
+    },
+    "related_analytics": {
+      "caption": "Related Analytics",
+      "description": "Describes analytics related to the analytic of a finding or detection as identified by the security product.",
+      "is_array": true,
+      "type": "analytic"
     },
     "risk_details": {
       "caption": "Risk Details",

--- a/dictionary.json
+++ b/dictionary.json
@@ -79,6 +79,16 @@
       "description": "The CIS critical security control.",
       "type": "string_t"
     },
+    "database": {
+      "caption": "Database",
+      "description": "The database object is used for databases which are typically datastore services that contain an organized collection of structured and unstructured data or a types of data.",
+      "type": "database"
+    },
+    "databucket": {
+      "caption": "Databucket",
+      "description": "The data bucket object is a basic container that holds data, typically organized through the use of data partitions.",
+      "type": "databucket"
+    },
     "data_sources": {
       "caption": "Data Sources",
       "description": "The data sources for the detection.",
@@ -298,6 +308,11 @@
       "description": "The network hosts of an endpoint or a device.",
       "is_array": true,
       "type": "string_t"
+    },
+    "org": {
+      "caption": "Organization",
+      "description": "Organization and org unit relevant to the event or object.",
+      "type": "organization"
     },
     "owners": {
       "caption": "Owners",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "uid": 1
 }

--- a/objects/analytic.json
+++ b/objects/analytic.json
@@ -1,0 +1,94 @@
+{
+    "caption": "Analytic",
+    "name": "analytic",
+    "description": "The Analytic object contains details about the analytic technique used to analyze and derive insights from the data or information that led to the creation of a finding or conclusion.",
+    "extends": "_entity",
+    "attributes": {
+      "category": {
+        "description": "The analytic category.",
+        "requirement": "optional"
+      },
+      "desc": {
+        "description": "The description of the analytic that generated the finding.",
+        "requirement": "optional"
+      },
+      "name": {
+        "description": "The name of the analytic that generated the finding."
+      },
+      "related_analytics": {
+        "@deprecated": {
+          "message": "Related Analytics has been decoupled from this object, instead use <code>finding_info.related_analytics</code>.",
+          "since": "1.0.0"
+        },
+        "description": "Other analytics related to this analytic.",
+        "requirement": "optional"
+      },
+      "type": {
+        "description": "The analytic type.",
+        "requirement": "optional"
+      },
+      "type_id": {
+        "description": "The analytic type ID.",
+        "requirement": "required",
+        "enum": {
+          "0": {
+            "caption": "Unknown"
+          },
+          "1": {
+            "caption": "Rule",
+            "description": "A Rule in security analytics refers to predefined criteria or conditions set to monitor, alert, or enforce policies, playing a crucial role in access control, threat detection, and regulatory compliance across security systems."
+          },
+          "2": {
+            "caption": "Behavioral",
+            "description": "Behavioral analytics focus on monitoring and analyzing user or system actions to identify deviations from established patterns, aiding in the detection of insider threats, fraud, and advanced persistent threats (APTs)."
+          },
+          "3": {
+            "caption": "Statistical",
+            "description": "Statistical analytics pertains to analyzing data patterns and anomalies using statistical models to predict, detect, and respond to potential threats, enhancing overall security posture through informed decision-making."
+          },
+          "4": {
+            "caption": "Learning (ML/DL)",
+            "description": "Learning (ML/DL) encompasses techniques that can \"learn\" from known data to create analytics that generalize to new data. There may be a statistical component to these techniques, but it is not a requirement."
+          },
+          "5": {
+            "caption": "Fingerprinting",
+            "description": "Fingerprinting is the technique of collecting detailed system data, including software versions and configurations, to enhance threat detection, data loss prevention (DLP), and endpoint detection and response (EDR) capabilities."
+          },
+          "6": {
+            "caption": "Tagging",
+            "description": "Tagging refers to the practice of assigning labels or identifiers to data, users, assets, or activities to monitor, control access, and facilitate incident response across various security domains such as DLP and EDR."
+          },
+          "7": {
+            "caption": "Keyword Match",
+            "description": "Keyword Match involves scanning content for specific terms to identify sensitive information, potential threats, or policy violations, aiding in DLP and compliance monitoring."
+          },
+          "8": {
+            "caption": "Regular Expressions",
+            "description": "Regular Expressions are used to define complex search patterns for identifying, validating, and extracting specific data sets or threats within digital content, enhancing DLP, EDR, and threat detection mechanisms."
+          },
+          "9": {
+            "caption": "Exact Data Match",
+            "description": "Exact Data Match is a precise comparison technique used to detect the unauthorized use or exposure of specific, sensitive information, crucial for enforcing DLP policies and protecting against data breaches."
+          },
+          "10": {
+            "caption": "Partial Data Match",
+            "description": "Partial Data Match involves identifying instances where segments of sensitive information or patterns match, facilitating nuanced DLP and threat detection without requiring complete data conformity."
+          },
+          "11": {
+            "caption": "Indexed Data Match",
+            "description": "Indexed Data Match refers to comparing content against a pre-compiled index of sensitive information to efficiently detect and prevent unauthorized access or breaches, streamlining DLP and compliance efforts."
+          },
+          "99": {
+            "caption": "Other"
+          }
+        }
+      },
+      "uid": {
+        "description": "The unique identifier of the analytic that generated the finding."
+      },
+      "version": {
+        "description": "The analytic version. For example: <code>1.1</code>.",
+        "requirement": "optional"
+      }
+    }
+  }


### PR DESCRIPTION
# Context
- Several attributes were missing from the dictionary after the recent addition of `Finding Info` and `Detection Finding`
- The `Analytic` object is needed

# Code changes
- Added the analytic object
- Added several missing attributes to the dictionary
- Reordered the dictionary so that it was alphabetical to match convention

# Testing
<img width="1719" alt="Screenshot 2024-07-08 at 8 32 20 AM" src="https://github.com/ocsf/splunk/assets/127444568/b95c0a2a-6609-402d-9fb2-b8f2179580f3">
<img width="1716" alt="Screenshot 2024-07-08 at 8 32 14 AM" src="https://github.com/ocsf/splunk/assets/127444568/410bcf6e-a4a1-4d03-95da-cffd0c6b3e08">
<img width="1693" alt="Screenshot 2024-07-08 at 8 32 06 AM" src="https://github.com/ocsf/splunk/assets/127444568/e47fd910-da9d-4ed6-b412-2ab067b85837">
