### PR TITLE
Adding missing objects and profile

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -89,6 +89,11 @@
       "description": "The data bucket object is a basic container that holds data, typically organized through the use of data partitions.",
       "type": "databucket"
     },
+    "data_classification": {
+      "caption": "Data Classification",
+      "description": "The Data Classification object includes information about data classification levels and data category types.",
+      "type": "data_classification"
+    },
     "data_sources": {
       "caption": "Data Sources",
       "description": "The data sources for the detection.",
@@ -313,6 +318,16 @@
       "caption": "Organization",
       "description": "Organization and org unit relevant to the event or object.",
       "type": "organization"
+    },
+    "ou_name": {
+      "caption": "Org Unit Name",
+      "description": "The name of the organizational unit, within an organization.  For example, Finance, IT, R&D",
+      "type": "string_t"
+    },
+    "ou_uid": {
+      "caption": "Org Unit ID",
+      "description": "The alternate identifier for an entity's unique identifier. For example, its Active Directory OU DN or AWS OU ID.",
+      "type": "string_t"
     },
     "owners": {
       "caption": "Owners",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "uid": 1
 }

--- a/objects/data_classification.json
+++ b/objects/data_classification.json
@@ -1,0 +1,66 @@
+{
+    "caption": "Data Classification",
+    "description": "The Data Classification object includes information about data classification levels and data category types.",
+    "extends": "object",
+    "name": "data_classification",
+    "attributes": {
+      "category": {
+        "description": "The name of the data classification category that data matched into, e.g. Financial, Personal, Governmental, etc.",
+        "requirement": "optional"
+      },
+      "category_id": {
+        "description": "The normalized identifier of the data classification category.",
+        "enum": {
+          "0": {
+            "caption": "Unknown",
+            "description": "The type is not mapped. See the <code>data_type</code> attribute, which contains a data source specific value."
+          },
+          "1": {
+            "caption": "Personal",
+            "description": "Any Personally Identifiable Information (PII), Electronic Personal Health Information (ePHI), or similarly personal information. E.g., full name, home address, date of birth, etc."
+          },
+          "2": {
+            "caption": "Governmental",
+            "description": "Any sensitive government identification number related to a person or other classified material. E.g., Passport numbers, driver license numbers, business identification, taxation identifiers, etc."
+          },
+          "3": {
+            "caption": "Financial",
+            "description": "Any financially-related sensitive information or Cardholder Data (CHD). E.g., banking account numbers, credit card numbers, International Banking Account Numbers (IBAN), SWIFT codes, etc."
+          },
+          "4": {
+            "caption": "Business",
+            "description": "Any business-specific sensitive data such as intellectual property, trademarks, copyrights, human resource data, Board of Directors meeting minutes, and similar."
+          },
+          "5": {
+            "caption": "Military and Law Enforcement",
+            "description": "Any mission-specific sensitive data for military, law enforcement, or other government agencies such as specifically classified data, weapon systems information, or other planning data."
+          },
+          "6": {
+            "caption": "Security",
+            "description": "Any sensitive security-related data such as passwords, passkeys, IP addresses, API keys, credentials and similar secrets. E.g., AWS Access Secret Key, SaaS API Keys, user passwords, database credentials, etc."
+          },
+          "99": {
+            "caption": "Other",
+            "description": "Any other type of data classification or a multi-variate classification made up of several other classification categories."
+          }
+        },
+        "requirement": "recommended"
+      },
+      "confidentiality": {
+        "requirement": "optional"
+      },
+      "confidentiality_id": {
+        "requirement": "recommended"
+      },
+      "policy": {
+        "description": "Details about the data policy that governs data handling and security measures related to classification.",
+        "requirement": "optional"
+      }
+    },
+    "constraints": {
+      "at_least_one": [
+        "category_id",
+        "confidentiality_id"
+      ]
+    }
+  }

--- a/objects/database.json
+++ b/objects/database.json
@@ -1,0 +1,74 @@
+{
+    "caption": "Database",
+    "description": "The database object is used for databases which are typically datastore services that contain an organized collection of structured and unstructured data or a types of data.",
+    "extends": "_entity",
+    "name": "database",
+    "profiles": [
+      "splunk/data_classification"
+    ],
+    "attributes": {
+      "$include": [
+        "profiles/data_classification.json"
+      ],
+      "created_time": {
+        "description": "The time when the database was known to have been created.",
+        "requirement": "optional"
+      },
+      "modified_time": {
+        "description": "The most recent time when any changes, updates, or modifications were made within the database.",
+        "requirement": "optional"
+      },
+      "desc": {
+        "description": "The description of the database.",
+        "requirement": "optional"
+      },
+      "size": {
+        "description": "The size of the database in bytes.",
+        "requirement": "optional"
+      },
+      "groups": {
+        "description": "The group names to which the database belongs.",
+        "requirement": "optional"
+      },
+      "type": {
+        "description": "The database type.",
+        "requirement": "recommended"
+      },
+      "type_id": {
+        "description": "The normalized identifier of the database type.",
+        "requirement": "required",
+        "enum": {
+          "0": {
+            "caption": "Unknown"
+          },
+          "1": {
+            "caption": "Relational"
+          },
+          "2": {
+            "caption": "Network"
+          },
+          "3": {
+            "caption": "Object Oriented"
+          },
+          "4": {
+            "caption": "Centralized"
+          },
+          "5": {
+            "caption": "Operational"
+          },
+          "6": {
+            "caption": "NoSQL"
+          },
+          "99": {
+            "caption": "Other"
+          }
+        }
+      },
+      "name": {
+        "description": "The database name, ordinarily as assigned by a database administrator."
+      },
+      "uid": {
+        "description": "The unique identifier of the database."
+      }
+    }
+  }

--- a/objects/databucket.json
+++ b/objects/databucket.json
@@ -1,0 +1,70 @@
+{
+    "caption": "Databucket",
+    "description": "The databucket object is a basic container that holds data, typically organized through the use of data partitions.",
+    "extends": "_entity",
+    "name": "databucket",
+    "profiles": [
+      "splunk/data_classification"
+    ],
+    "attributes": {
+      "$include": [
+        "profiles/data_classification.json"
+      ],
+      "created_time": {
+        "description": "The time when the databucket was known to have been created.",
+        "requirement": "optional"
+      },
+      "modified_time": {
+        "description": "The most recent time when any changes, updates, or modifications were made within the databucket.",
+        "requirement": "optional"
+      },
+      "desc": {
+        "caption": "Description",
+        "description": "The description of the databucket.",
+        "requirement": "optional"
+      },
+      "size": {
+        "description": "The size of the databucket in bytes.",
+        "requirement": "optional"
+      },
+      "file": {
+        "description": "A file within a databucket.",
+        "requirement": "optional"
+      },
+      "groups": {
+        "description": "The group names to which the databucket belongs.",
+        "requirement": "optional"
+      },
+      "type": {
+        "description": "The databucket type.",
+        "requirement": "recommended"
+      },
+      "type_id": {
+        "description": "The normalized identifier of the databucket type.",
+        "requirement": "required",
+        "enum": {
+          "0": {
+            "caption": "Unknown"
+          },
+          "1": {
+            "caption": "S3"
+          },
+          "2": {
+            "caption": "Azure Blob"
+          },
+          "3": {
+            "caption": "GCP Bucket"
+          },
+          "99": {
+            "caption": "Other"
+          }
+        }
+      },
+      "name": {
+        "description": "The databucket name."
+      },
+      "uid": {
+        "description": "The unique identifier of the databucket."
+      }
+    }
+  }

--- a/objects/organization.json
+++ b/objects/organization.json
@@ -1,0 +1,20 @@
+{
+    "caption": "Organization",
+    "description": "The Organization object describes characteristics of an organization or company and its division if any.",
+    "extends": "_entity",
+    "name": "organization",
+    "attributes": {
+      "name": {
+        "description": "The name of the organization. For example, Widget, Inc."
+      },
+      "ou_name": {
+        "requirement": "recommended"
+      },
+      "ou_uid": {
+        "requirement": "optional"
+      },
+      "uid": {
+        "description": "The unique identifier of the organization. For example, its Active Directory or AWS Org ID."
+      }
+    }
+  }

--- a/profiles/data_classification.json
+++ b/profiles/data_classification.json
@@ -1,0 +1,12 @@
+{
+    "description": "The attributes that describe information specific to data classification.",
+    "meta": "profile",
+    "caption": "Data Classification",
+    "name": "data_classification",
+    "attributes": {
+      "data_classification": {
+        "group": "context",
+        "requirement": "recommended"
+      }
+    }
+  }


### PR DESCRIPTION
# Context
* In #23 I added some attribute definitions that we're missing, but neglected to add the corresponding object definition for `database`, `databucket` and `organization`

# Code Changes
* Added object definitions for `database`, `databucket` and `organization`
* Added profile and object definition for `data_classification`
* Bumped patch version

# Testing
`data_classification`
<img width="1573" alt="Screenshot 2024-07-11 at 7 15 10 AM" src="https://github.com/ocsf/splunk/assets/127444568/89441740-cce9-45ff-8376-f45e249b581e">

`database`
<img width="1722" alt="Screenshot 2024-07-11 at 7 15 25 AM" src="https://github.com/ocsf/splunk/assets/127444568/a0d9d246-24c4-4962-85ad-0e8bae60dbc0">

`databucket`
<img width="1726" alt="Screenshot 2024-07-11 at 7 15 40 AM" src="https://github.com/ocsf/splunk/assets/127444568/b7f8af5a-7be1-4600-9211-deebe0224334">

`organization`
<img width="1531" alt="Screenshot 2024-07-11 at 7 16 09 AM" src="https://github.com/ocsf/splunk/assets/127444568/372423a7-0301-4df2-bc20-29f035747f2e">

Requsting `entity_management` no longer throws a 500
<img width="1726" alt="Screenshot 2024-07-11 at 7 18 26 AM" src="https://github.com/ocsf/splunk/assets/127444568/2b8e7ae0-a1aa-4791-a256-73f685328800">
