### PR TITLE
SESA-1296 Add autonomous_system object, update ext version

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -14,6 +14,11 @@
       "is_array": true,
       "type": "string_t"
     },
+    "autonomous_system": {
+      "caption": "Autonomous System",
+      "description": "The Autonomous System details associated with an IP address.",
+      "type": "autonomous_system"
+    },
     "caller": {
       "caption": "Caller",
       "description": "The point of origin from which the action was directed. Its values are derived via business logic. This usually represents the inferred source entity for a logon.",
@@ -313,6 +318,11 @@
       "description": "The network hosts of an endpoint or a device.",
       "is_array": true,
       "type": "string_t"
+    },
+    "number": {
+      "caption": "Number",
+      "description": "The number of the entity. See specific usage.",
+      "type": "integer_t"
     },
     "org": {
       "caption": "Organization",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "uid": 1
 }

--- a/objects/autonomous_system.json
+++ b/objects/autonomous_system.json
@@ -1,0 +1,25 @@
+{
+  "caption": "Autonomous System",
+  "description": "An autonomous system (AS) is a collection of connected Internet Protocol (IP) routing prefixes under the control of one or more network operators on behalf of a single administrative entity or domain that presents a common, clearly defined routing policy to the internet.",
+  "extends": "object",
+  "name": "autonomous_system",
+  "attributes": {
+    "number": {
+      "description": "Unique number that the AS is identified by.",
+      "requirement": "recommended",
+      "group": "context",
+      "type": "integer_t"
+    },
+    "name": {
+      "description": "Organization name for the Autonomous System.",
+      "requirement": "recommended",
+      "group": "context"
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+      "number",
+      "name"
+    ]
+  }
+}

--- a/objects/network_endpoint_ex.json
+++ b/objects/network_endpoint_ex.json
@@ -5,6 +5,9 @@
     "splunk/ba"
   ],
   "attributes": {
+    "autonomous_system": {
+      "requirement": "optional"
+    },
     "os": {
       "description": "The endpoint operating system.",
       "requirement": "optional"


### PR DESCRIPTION
When doing the mapping for Okta events, we found that the `securityContext` field provides context about `isp`, `ASN`, etc., which in OCSF v1.x there is an `autonomous_system` object. We can add this to our extension to be closer to 1.x support while enhancing our mappings.

- [x] Add the `autonomous_system` object to the extension (objects folder and dictionary)
- [x] Add the `number` attribute to the dictionary.
- [x] Add the `autonomous_system` object to the `network_endpoint` extended object.
- [x] Update the extension version.

<img width="774" alt="image" src="https://github.com/ocsf/splunk/assets/91983279/f8f21b28-590d-4e68-b793-759aeeb87ebc">

<img width="863" alt="image" src="https://github.com/ocsf/splunk/assets/91983279/3799d778-ad98-47cf-9b02-9ff9fcf4f78f">
