### PR TITLE
Downgrade dst_endpoint to recommended to match 1.x

### DIFF
--- a/events/audit/authentication.json
+++ b/events/audit/authentication.json
@@ -33,6 +33,11 @@
         }
       }
     },
+    "dst_endpoint": {
+      "description": "The endpoint to which the authentication was targeted.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
     "is_new_logon": {
       "group": "context",
       "requirement": "optional"

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "uid": 1
 }


### PR DESCRIPTION
This PR downgrades the `dst_endpoint` field in the `Authentication` class from `Required` to `Recommended` to reach field parity with OCSF Core 1.x versions

Was:

<img width="969" alt="image" src="https://github.com/user-attachments/assets/000f0c06-f0c5-430b-a3bb-22d2980a7fb4">


Is now:

<img width="951" alt="image" src="https://github.com/user-attachments/assets/396a7ec3-5cde-4bd5-bb13-54afc1f44868">

This change is up on our dev server for validation.
