### PR TITLE
Add http_request, roll minor version

### DIFF
--- a/events/audit/entity.json
+++ b/events/audit/entity.json
@@ -78,6 +78,11 @@
       "group": "primary",
       "requirement": "recommended"
     },
+    "http_request": {
+      "description": "Details about the underlying HTTP request.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "src_endpoint": {
       "description": "Details about the source of the IAM activity.",
       "group": "primary",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "uid": 1
 }


### PR DESCRIPTION
This PR adds the `http_request` attribute to the `Entity Management` class for better Okta support. This field was introduced to the class in OCSF version 1.2.0.

<img width="805" alt="image" src="https://github.com/user-attachments/assets/8c4c8427-1ded-418d-a198-f88bb5c44781">

Tested locally and on `dev`.