### PR TITLE
SESA-1320: Fix broken string subtypes in 1.0.0-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Splunk OCSF Extension
-The Splunk schema extension repository
+This is the Splunk schema extension repository.
+
+This extension is designed to work with the [OCSF schema](https://github.com/ocsf/ocsf-schema) version [1.0.0-rc.2](https://github.com/ocsf/ocsf-schema/tree/v1.0.0-rc.2). The extension some adds fields specific to Splunk's internal usage, plus back-ports of a number of changes from later versions of the schema to work with 1.0.0-rc.2.

--- a/dictionary.json
+++ b/dictionary.json
@@ -598,5 +598,24 @@
       "is_array": true,
       "type": "user"
     }
+  },
+  "types": {
+    "attributes": {
+      "bytestring_t": {
+        "type": "string_t"
+      },
+      "file_hash_t": {
+        "type": "string_t"
+      },
+      "resource_uid_t": {
+        "type": "string_t"
+      },
+      "subnet_t": {
+        "type": "string_t"
+      },
+      "uuid_t": {
+        "type": "string_t"
+      }
+    }
   }
 }

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "uid": 1
 }


### PR DESCRIPTION
Five of the subtypes in the 1.0.0-rc.2 schema are missing the `type` field specifying `string_t`. This is fixed in later versions of the schema. 

These missing super-type attributes, besides being technically incorrect, lead to invalid JSON Schema for classes that use attributes of these types.

Since RC2 can no longer be changed, we add the missing attributes here in the Splunk extension. Fortunately this works.

As an exercise for reviewers, you can look at the `dictionary.json` of the 1.0.0-rc.2 schema branch and compare that to later versions of the schema to see these `type` fields added. You could even run the OCSF Server with rc2 and this MR's Splunk extension, then download a JSON Schema like for `account_change` class (as an example), and see the lack of `file_hash_t` and `subnet_t` in the "fixed" JSON Schema.

