### PR TITLE
Add category_id to dictionary

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -35,6 +35,12 @@
       "description": "The object category. See specific usage.",
       "type": "string_t"
     },
+    "category_id": {
+      "caption": "Category ID",
+      "description": "The normalized identifier of the object category. See specific usage.",
+      "sibling": "category",
+      "type": "integer_t"
+    },
     "client_interface": {
       "caption": "Client Interface",
       "description": "The client interface. See specific usage.",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "uid": 1
 }


### PR DESCRIPTION
Adds missing `category_id` to the Splunk extension dictionary. This is needed to fix a bug wherein the `Detection Finding` class would not export its JSON schema.