### PR TITLE
Add file_result to Network File Activity class

### DIFF
--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -96,6 +96,11 @@
       "group": "primary",
       "requirement": "required"
     },
+    "file_result": {
+      "description": "The resulting file object when the activity was allowed and successful.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "src_endpoint": {
       "description": "The endpoint that performed the activity on the target file.",
       "group": "primary",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.5.2",
+  "version": "1.6.2",
   "uid": 1
 }

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.6.2",
+  "version": "1.6.0",
   "uid": 1
 }


### PR DESCRIPTION
To support some O365 events which have the `ObjectType` value as a file path, we noticed that the `file_result` field should be added to adequately map the event. 

This PR adds the `file_result` field to this extension event, which already exists in OCSF 1.x versions.

<img width="720" alt="image" src="https://github.com/user-attachments/assets/51236009-78a0-43dd-8476-98d6cdad208c">

Since there was a change to this class, for good measure we verified that the Json schema exports as expected:

<img width="652" alt="image" src="https://github.com/user-attachments/assets/ee5aab80-828d-47e9-9108-7209c9ee35bf">

This is also up on the dev server for review prior to updating in production.