### PR TITLE
Add-forward_addr

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3,6 +3,11 @@
   "description": "The Attribute Dictionary defines schema attributes and includes references to the events and objects in which they are used.",
   "name": "dictionary",
   "attributes": {
+    "account": {
+      "caption": "Account",
+      "description": "The account object describes details about the account that was the source or target of the activity.",
+      "type": "account"
+    },
     "analytic": {
       "caption": "Analytic",
       "description": "The analytic technique used to analyze and derive insights from the data or information that led to the finding or conclusion.",
@@ -217,6 +222,11 @@
       "caption": "Finding Information",
       "description": "Describes the supporting information about a generated finding.",
       "type": "finding_info"
+    },
+    "forward_addr": {
+      "caption": "Forwarding Address",
+      "description": "The user's forwarding email address.",
+      "type": "email_t"
     },
     "full_name": {
       "caption": "Full Name",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "uid": 1
 }

--- a/objects/account.json
+++ b/objects/account.json
@@ -1,0 +1,95 @@
+{
+  "caption": "Account",
+  "description": "The Account object contains details about the account that initiated or performed a specific activity within a system or application. Additionally, the Account object refers to logical Cloud and Software-as-a-Service (SaaS) based containers such as AWS Accounts, Azure Subscriptions, Oracle Cloud Compartments, Google Cloud Projects, and otherwise.",
+  "name": "account",
+  "extends": "_entity",
+  "attributes": {
+    "name": {
+      "description": "The name of the account (e.g. <code> GCP Project name </code>, <code> Linux Account name </code> or <code> AWS Account name </code>).",
+      "observable": 34
+    },
+    "type": {
+      "caption": "Type",
+      "description": "The account type, normalized to the caption of 'account_type_id'. In the case of 'Other', it is defined by the event source.",
+      "requirement": "optional"
+    },
+    "type_id": {
+      "caption": "Type ID",
+      "description": "The normalized account type identifier.",
+      "enum": {
+        "99": {
+          "caption": "Other",
+          "description": "The account type is not mapped."
+        },
+        "0": {
+          "caption": "Unknown",
+          "description": "The account type is unknown."
+        },
+        "1": {
+          "caption": "LDAP Account"
+        },
+        "2": {
+          "caption": "Windows Account"
+        },
+        "3": {
+          "caption": "AWS IAM User"
+        },
+        "4": {
+          "caption": "AWS IAM Role"
+        },
+        "5": {
+          "caption": "GCP Account"
+        },
+        "6": {
+          "caption": "Azure AD Account"
+        },
+        "7": {
+          "caption": "Mac OS Account"
+        },
+        "8": {
+          "caption": "Apple Account"
+        },
+        "9": {
+          "caption": "Linux Account"
+        },
+        "10": {
+          "caption": "AWS Account"
+        },
+        "11": {
+          "caption": "GCP Project"
+        },
+        "12": {
+          "caption": "OCI Compartment"
+        },
+        "13": {
+          "caption": "Azure Subscription"
+        },
+        "14": {
+          "caption": "Salesforce Account"
+        },
+        "15": {
+          "caption": "Google Workspace"
+        },
+        "16": {
+          "caption": "Servicenow Instance"
+        },
+        "17": {
+          "caption": "M365 Tenant"
+        },
+        "18": {
+          "caption": "Email Account"
+        }
+      },
+      "requirement": "recommended"
+    },
+    "uid": {
+      "description": "The unique identifier of the account (e.g. <code> AWS Account ID </code>, <code> OCID </code>, <code> GCP Project ID </code>, <code> Azure Subscription ID </code>, <code> Google Workspace Customer ID </code>, or <code> M365 Tenant UID </code>).",
+      "observable": 35
+    },
+    "labels": {
+      "caption": "Labels",
+      "description": "The list of labels/tags associated to the account.",
+      "requirement": "optional"
+    }
+  }
+}

--- a/objects/user_ex.json
+++ b/objects/user_ex.json
@@ -17,6 +17,9 @@
       "profile": "splunk/ba",
       "requirement": "optional"
     },
+    "forward_addr": {
+      "requirement": "optional"
+    },
     "full_name": {
       "profile": "splunk/ba",
       "requirement": "optional"

--- a/objects/user_ex.json
+++ b/objects/user_ex.json
@@ -5,6 +5,10 @@
     "splunk/ba"
   ],
   "attributes": {
+    "account": {
+      "description": "The user's account or the account associated with the user.",
+      "requirement": "optional"
+    },
     "email_addresses": {
       "profile": "splunk/ba",
       "requirement": "optional"


### PR DESCRIPTION
This PR:

1. Adds the `forward_addr` atrribute to the `user` object.
2. Adds the `account` object to the `user` object with an account type_id enum for `Email Account`.
3. Updates the extension version.

<img width="951" alt="image" src="https://github.com/user-attachments/assets/1092f0b7-4994-4184-93fd-7c953f9c5cee">

<img width="866" alt="image" src="https://github.com/user-attachments/assets/cd9d5300-01a6-422d-a65f-b89b84d7d96e">

These updates were made to OCSF Core v1.4.0. We are adding them to our Splunk extension so we may utilize them with OCSF rc2.

Testing:

Verified the expected attributes/objects are present on the server, and ensured the JSON Schema exports without error.