### PR TITLE
Add 'tags' to metadata as key_value_object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -582,6 +582,12 @@
       "description": "The start date of a user's employment.",
       "type": "timestamp_t"
     },
+    "tags": {
+      "caption": "Tags",
+      "description": "The list of tags; <code>{key:value}</code> pairs attached to an entity. A Tag may be used to categorize, filter, and search for entities. For e.g. <code>\"Environment\": \"Production\"</code>, <code>\"Owner\": \"007\"</code>. See specific usage.",
+      "type": "key_value_object",
+      "is_array": true
+    },
     "target": {
       "caption": "Target",
       "description": "The desired entity towards which the action is directed. Its values are derived via business logic. This usually represents the inferred destination entity for a logon.",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "uid": 1
 }

--- a/objects/key_value_object.json
+++ b/objects/key_value_object.json
@@ -1,0 +1,16 @@
+{
+  "caption": "Key:Value object",
+  "description": "A generic object allowing to define a <code>{key:value}</code> pair.",
+  "extends": "object",
+  "name": "key_value_object",
+  "attributes": {
+    "name": {
+      "description": "The name of the key.",
+      "requirement": "required"
+    },
+    "value": {
+      "description": "The value associated to the key.",
+      "requirement": "required"
+    }
+  }
+}

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -35,6 +35,10 @@
     "source_type": {
       "profile": "splunk/ba",
       "requirement": "recommended"
+    },
+    "tags": {
+      "description": "The list of tags; <code>{key:value}</code> pairs associated to the event.",
+      "requirement": "optional"
     }
   }
 }


### PR DESCRIPTION
This PR makes the [`metadata.tags` array](https://schema.ocsf.io/1.4.0-dev/objects/metadata?extensions=) available within the Splunk extension.

1. Adds the `key_value_object`.
2. Adds the `tags` array to the `dictionary`
3. Adds the `tags` array as an attribute to the `metadata` object.

<img width="899" alt="image" src="https://github.com/user-attachments/assets/0c276687-cec9-4592-87b1-b74c60eb9345">

<img width="793" alt="image" src="https://github.com/user-attachments/assets/6e48f0e4-f5f9-41a4-82ac-9d9c0d2bd79f">
