### PR TITLE
Add `Trace` activity_id to `Email Activity` class

### DIFF
--- a/events/network/email_activity.json
+++ b/events/network/email_activity.json
@@ -1,0 +1,17 @@
+{
+  "description": "The extended Email Activity class.",
+  "extends": "email_activity",
+  "profiles": [
+    "splunk/ba"
+  ],
+  "attributes": {
+    "activity_id": {
+      "enum": {
+        "4": {
+          "caption": "Trace",
+          "description": "Follow an email message as it travels through an organization. For example: <a target='_blank' href='https://learn.microsoft.com/en-us/Exchange/monitoring/trace-an-email-message/message-trace-modern-eac'>O365 Email Message Trace</a>."
+        }
+      }
+    }
+  }
+}

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "uid": 1
 }


### PR DESCRIPTION
Description of changes:
This PR adds a useful new activity_id to the Email Activity class: Trace. This is in accordance with OCSF `1.4.0` and allows us to begin mapping o365 messagetrace events to OCSF.

Trace events follow an email message as it travels through an organization. For example: [O365 Email Message Trace](https://learn.microsoft.com/en-us/Exchange/monitoring/trace-an-email-message/message-trace-modern-eac).

<img width="1059" alt="image" src="https://github.com/user-attachments/assets/a2c74db1-7eb5-4334-9951-c5438bb1be75">
