### PR TITLE
SESA-1391 Port Email Activity Updates

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -128,6 +128,17 @@
       "is_array": true,
       "type": "device"
     },
+    "domain": {
+      "caption": "Domain",
+      "description": "The name of the domain. See specific usage.",
+      "type": "string_t"
+    },
+    "domains": {
+      "caption": "Domains",
+      "description": "The domains that pertain to the event or object. See specific usage.",
+      "type": "string_t",
+      "is_array": true
+    },
     "email_addresses": {
       "caption": "Email Addresses",
       "description": "The user's additional email addresses.",
@@ -217,6 +228,12 @@
           "caption": "Other"
         }
       }
+    },
+    "files": {
+      "caption": "Files",
+      "description": "The files that are part of the event or object.",
+      "type": "file",
+      "is_array": true
     },
     "finding_info": {
       "caption": "Finding Information",
@@ -394,6 +411,12 @@
     "managed_by": {
       "caption": "Managed By",
       "description": "The distinguished name of the user that is assigned to manage this object.",
+      "type": "string_t"
+    },
+    "message_trace_uid": {
+      "caption": "Message Trace UID",
+      "description": "The identifier that tracks a message that travels through multiple points of a messaging service.",
+      "references": [{"url": "https://learn.microsoft.com/en-us/previous-versions/office/developer/o365-enterprise-developers/jj984335(v=office.15)", "description": "For example Office 365 Message Trace Report."}],
       "type": "string_t"
     },
     "nicknames": {
@@ -613,6 +636,12 @@
       "description": "The normalized tunnel type ID.",
       "sibling": "tunnel_type",
       "type": "integer_t"
+    },
+    "urls": {
+      "caption": "URLs",
+      "description": "The URLs that pertain to the event or object.",
+      "type": "url",
+      "is_array": true
     },
     "users": {
       "caption": "Users",

--- a/events/network/email_activity.json
+++ b/events/network/email_activity.json
@@ -9,9 +9,17 @@
       "enum": {
         "4": {
           "caption": "Trace",
-          "description": "Follow an email message as it travels through an organization. For example: <a target='_blank' href='https://learn.microsoft.com/en-us/Exchange/monitoring/trace-an-email-message/message-trace-modern-eac'>O365 Email Message Trace</a>."
+          "description": "Follow an email message as it travels through an organization. The <code>message_trace_uid</code> should be populated when selected.",
+          "references": [{"url": "href='https://learn.microsoft.com/en-us/Exchange/monitoring/trace-an-email-message/message-trace-modern-eac", "description": "For example Office 365 Email Message Trace"}]
         }
       }
+    },
+    "email_uid": {
+      "group": "primary"
+    },
+    "message_trace_uid": {
+      "group": "primary",
+      "requirement": "recommended"
     }
   }
 }

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "uid": 1
 }

--- a/objects/email.json
+++ b/objects/email.json
@@ -1,0 +1,94 @@
+{
+  "description": "The extended/enriched Email object.",
+  "extends": "email",
+  "profiles": [
+    "splunk/ba"
+  ],
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:Email/", "description": "D3FEND™ Ontology d3f:Email."}],
+  "attributes": {
+    "account": {
+      "description": "The user's account or the account associated with the user.",
+      "requirement": "optional"
+    },
+    "domains": {
+      "requirement": "optional",
+      "description": "The domain names seen in the email. For example <code>www.w3.org</code> or <code>ocsf.io</code>."
+    },
+    "email_addresses": {
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "end_date": {
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "files": {
+      "requirement": "optional",
+      "description": "The files embedded or attached to the email."
+    },
+    "forward_addr": {
+      "requirement": "optional"
+    },
+    "from": {
+      "requirement": "recommended"
+    },
+    "full_name": {
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "home_folder": {
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "labels": {
+      "description": "The list of labels attached to the user.",
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "location": {
+      "description": "The geographical location of the user's office.",
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "managed_by": {
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "nicknames": {
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "phones": {
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "privileges": {
+      "description": "The user privileges.",
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "shell": {
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "start_date": {
+      "profile": "splunk/ba",
+      "requirement": "optional"
+    },
+    "to": {
+      "requirement": "recommended"
+    },
+    "urls": {
+      "requirement": "optional",
+      "description": "The URLs embedded in the email."
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+      "from",
+      "to",
+      "smtp_from",
+      "smtp_to"
+    ]
+  }
+}


### PR DESCRIPTION
This PR ports over the email activity updates from `OCSF 1.4.0` in order to allow us to map o365 messagetrace events.

# Summary:
- Adds dictionary attributes
- Relaxes the `from` and `to` requirement to `recommended`, with a new constraint set.
- Adds attributes to the `email` object.

<img width="1349" alt="image" src="https://github.com/user-attachments/assets/ed3ccab1-1bf9-4410-84b0-0abdb8b31de1">

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/979b86e3-26fe-4a10-adeb-5221ccdd4d08">
