### PR TITLE
Port uid_alt attribute to Extension

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -637,6 +637,11 @@
       "sibling": "tunnel_type",
       "type": "integer_t"
     },
+    "uid_alt": {
+      "caption": "Alternate ID",
+      "description": "The alternate unique identifier. See specific usage.",
+      "type": "string_t"
+    },
     "urls": {
       "caption": "URLs",
       "description": "The URLs that pertain to the event or object.",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "uid": 1
 }

--- a/objects/device_ex.json
+++ b/objects/device_ex.json
@@ -88,6 +88,10 @@
         }
       },
       "requirement": "recommended"
+    },
+    "uid_alt": {
+      "description": "An alternate unique identifier of the device if any. For example the ActiveDirectory DN.",
+      "requirement": "optional"
     }
   }
 }

--- a/objects/session_ex.json
+++ b/objects/session_ex.json
@@ -4,6 +4,10 @@
   "attributes": {
     "is_vpn": {
       "requirement": "optional"
+    },
+    "uid_alt": {
+      "description": "The alternate unique identifier of the session. e.g. AWS ARN - <code>arn:aws:sts::123344444444:assumed-role/Admin/example-session</code>.",
+      "requirement": "optional"
     }
   }
 }

--- a/objects/user_ex.json
+++ b/objects/user_ex.json
@@ -62,6 +62,10 @@
     "start_date": {
       "profile": "splunk/ba",
       "requirement": "optional"
+    },
+    "uid_alt": {
+      "description": "The alternate user identifier. For example, the Active Directory user GUID or AWS user Principal ID.",
+      "requirement": "optional"
     }
   }
 }


### PR DESCRIPTION
OCSF rc2 did not have a `user.uid_alt` field, but OCSF does have a `user.uid_alt` field which was added as of [OCSF 1.0](https://schema.ocsf.io/1.0.0/objects/user?extensions=).

In order to map this field for Okta events and other future mappings, we need to port the `uid_alt` field to the Splunk extension.

This PR:

- Adds `uid_alt` to the dictionary per 1.4 spec.
- Adds `uid_alt` to the following rc2 attributes in accordance with the 1.4 spec:
  - `user` object
  - `session` object
  - `device` object

<img width="572" alt="image" src="https://github.com/user-attachments/assets/33f6ecc1-87a3-4dbe-ac53-6eedca58a8c9" />

<img width="991" alt="image" src="https://github.com/user-attachments/assets/676d0d37-5b79-4aff-bafd-fbadc8b823c4" />

<img width="946" alt="image" src="https://github.com/user-attachments/assets/721fae7d-39e0-4a3c-968e-062c35dd890c" />

<img width="939" alt="image" src="https://github.com/user-attachments/assets/d162eea7-2a54-4685-b565-01c227f70d8f" />
