### PR TITLE
Reconcile Group Mgmt Class and Audit Base with 1.x

### DIFF
--- a/events/audit/audit_base.json
+++ b/events/audit/audit_base.json
@@ -4,5 +4,21 @@
   "extends": "audit",
   "name": "audit_base",
   "uid": 0,
-  "attributes": {}
+  "attributes": {
+    "http_request": {
+      "description": "Details about the underlying HTTP request.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "http_response": {
+      "description": "Details about the underlying HTTP response.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "src_endpoint": {
+      "description": "Details about the source of the IAM activity.",
+      "group": "primary",
+      "requirement": "recommended"
+    }
+  }
 }

--- a/events/audit/group_management.json
+++ b/events/audit/group_management.json
@@ -1,27 +1,35 @@
 {
+  "uid": 6,
   "caption": "Group Management",
   "description": "Group Management events report management updates to a group, including updates to membership and permissions.",
   "extends": "audit_base",
   "name": "group_management",
-  "uid": 6,
   "attributes": {
     "activity_id": {
       "enum": {
         "1": {
-          "description": "Assign privileges to a group.",
-          "caption": "Assign Privileges"
+          "caption": "Assign Privileges",
+          "description": "Assign privileges to a group."
         },
         "2": {
-          "description": "Revoke privileges from a group.",
-          "caption": "Revoke Privileges"
+          "caption": "Revoke Privileges",
+          "description": "Revoke privileges from a group."
         },
         "3": {
-          "description": "Add user to a group.",
-          "caption": "Add User"
+          "caption": "Add User",
+          "description": "Add user to a group."
         },
         "4": {
-          "description": "Remove user from a group.",
-          "caption": "Remove User"
+          "caption": "Remove User",
+          "description": "Remove user from a group."
+        },
+        "5": {
+          "caption": "Delete",
+          "description": "A group was deleted."
+        },
+        "6": {
+          "caption": "Create",
+          "description": "A group was created."
         }
       }
     },
@@ -32,6 +40,11 @@
     },
     "privileges": {
       "description": "A list of privileges assigned to the group.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "resource": {
+      "description": "Resource that the privileges give access to.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "uid": 1
 }


### PR DESCRIPTION
Related Ticket: SESA-1464

# Summary

This PR reconciles the Group Management class and Audit Base with 1.x so that its attributes can be used for rc2 Okta Mappings.

# Details

1. Adds the `http_request`, `http_response`, and `src_endpoint` attributes to `audit_base.json` (the 1.x is `iam.json`)
2. Adds the `Delete` and `Create` activity IDs to the `Group Management` class.
3. Adds the `resource` object to the `Group Management` class.
4. Sorts the captions and descriptions.

# Results

The `Delete` and `Create` activity IDs are available in the `Group Management` class.

<img width="1245" alt="image" src="https://github.com/user-attachments/assets/423276b7-2f94-40f1-8252-e0b54daab3fa" />

The `http_request/response`, `src_endpoint`, and `resource` attributes are now available for classes in the `Audit` category.

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/e64c1d85-551f-44cd-a728-3245ea5f9100" />

<img width="853" alt="image" src="https://github.com/user-attachments/assets/a43dc66a-96dc-4b16-8946-ffb03fc52ae7" />


# Testing

- [x] Verified the expected fields exist with the expected requirements.
- [x] Verified that the schema json exports.

<img width="306" alt="image" src="https://github.com/user-attachments/assets/09628be5-337e-488c-a787-a55cb11891a6" />

- [x] Ran validation for all existing OCSF translation rules against the new rc2/ext build:

<img width="374" alt="image" src="https://github.com/user-attachments/assets/a706b576-5f79-43f1-8d16-6577238dbe1b" />
