### PR TITLE
Port `display_name` attribute from OCSF core to rc2 Spunk Extension SESA-1469

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -178,6 +178,11 @@
       "is_array": true,
       "type": "device"
     },
+    "display_name": {
+      "caption": "Display Name",
+      "description": "The display name. See specific usage.",
+      "type": "string_t"
+    },
     "domain": {
       "caption": "Domain",
       "description": "The name of the domain. See specific usage.",
@@ -324,7 +329,7 @@
     },
     "full_name": {
       "caption": "Full Name",
-      "description": "The user's full name.",
+      "description": "The full name. See specific usage.",
       "type": "string_t"
     },
     "geohash": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.14.0",
+  "version": "1.13.2",
   "uid": 1
 }

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "uid": 1
 }

--- a/objects/user_ex.json
+++ b/objects/user_ex.json
@@ -9,6 +9,10 @@
       "description": "The user's account or the account associated with the user.",
       "requirement": "optional"
     },
+    "display_name": {
+      "description": "The display name of the user, as reported by the product.",
+      "requirement": "optional"
+    },
     "email_addresses": {
       "profile": "splunk/ba",
       "requirement": "optional"
@@ -21,7 +25,7 @@
       "requirement": "optional"
     },
     "full_name": {
-      "profile": "splunk/ba",
+      "description": "The full name of the user, as reported by the product.",
       "requirement": "optional"
     },
     "home_folder": {


### PR DESCRIPTION
**Related PR**: https://github.com/ocsf/ocsf-schema/pull/1341

----

**This PR**:

- [x] Adds the `display_name` attribute to the dictionary.
- [x] Adds the `display_name` attribute to the `user` object.
- [x] Relaxes the description of the `full_name` attribute so it can be used with a broader range of products, technologies, and implementations. In the attribute dictionary, the `See specific usage.` convention is applied.

<img width="1025" alt="image" src="https://github.com/user-attachments/assets/deac8c8a-6860-43e7-986f-70fa149ee19d" />

----
**Caveats:**

- [x]  `ldap_person` object is not in rc2, so `display_name` was not added to it in the extension.
- [ ] `full_name` is unused in OCSF core `email object` and is not used by our mapping definitions. Maybe it should be removed from the extension's `email` object.

----
**Issues Observed**:

- [x] dictionary defintions are not showing up properly (should read `The full/display name. See specific usage.`) - resolved by https://github.com/ocsf/ocsf-server/pull/133

<img width="1031" alt="image" src="https://github.com/user-attachments/assets/fdf6f186-0e0d-44ee-b6ec-f8d5450a3fe8" />

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/110886a3-cdc0-40dd-84f2-836607a21084" />
