### PR TITLE
Port the `user_access` class from OCSF Core 1.4.0

### DIFF
--- a/events/audit/user_access.json
+++ b/events/audit/user_access.json
@@ -1,0 +1,36 @@
+{
+  "uid": 5,
+  "caption": "User Access Management",
+  "description": "User Access Management events report management updates to a user's privileges.",
+  "extends": "audit_base",
+  "name": "user_access",
+  "attributes": {
+    "activity_id": {
+      "enum": {
+        "1": {
+          "caption": "Assign Privileges",
+          "description": "Assign privileges to a user."
+        },
+        "2": {
+          "caption": "Revoke Privileges",
+          "description": "Revoke privileges from a user."
+        }
+      }
+    },
+    "privileges": {
+      "description": "List of privileges assigned to a user.",
+      "group": "primary",
+      "requirement": "required"
+    },
+    "resource": {
+      "description": "Resource that the privileges give access to.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "user": {
+      "description": "User to which privileges were assigned.",
+      "group": "primary",
+      "requirement": "required"
+    }
+  }
+}

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "uid": 1
 }


### PR DESCRIPTION
# Summary
This PR ports the [User Access Management class](https://github.com/ocsf/ocsf-schema/blob/6d5d59cb7572c5561ec46d0f2bbeb7b323bc1b24/events/iam/user_access.json) to the [rc2 Splunk Extension](https://github.com/ocsf/splunk/tree/d16704c128715edbab0f70730a455fcd9048f380/events) for use with Okta [user.account.privilege.grant](https://splunk.atlassian.net/wiki/x/iJNcGvs). This is a dependency of Okta mapping efforts.

<img width="898" alt="image" src="https://github.com/user-attachments/assets/4dca3122-aa9b-4e81-9dea-fe281fb2dc11" />


# Checklist

- [x] Ported the `User Access Management` class.
- [x] Updated extension version.
- [x] Verified the JSON Schema exports without errors.
- [x] Verified all attributes/objects exist and are referenced by the rc2/extn dictionary .
- [x] Verified that all attributes have requirements set.
- [x] Double checked class constraints - no constraints exist today for this class. 