### PR TITLE
SESA-1475 Add the `authentication_token` object to the `authentication` class

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -19,6 +19,11 @@
       "is_array": true,
       "type": "string_t"
     },
+    "authentication_token": {
+      "caption": "Authentication Token",
+      "description": "The authentication token, ticket, or assertion. See specific usage.",
+      "type": "authentication_token"
+    },
     "autonomous_system": {
       "caption": "Autonomous System",
       "description": "The Autonomous System details associated with an IP address.",
@@ -204,6 +209,11 @@
       "description": "The user's additional email addresses.",
       "is_array": true,
       "type": "email_t"
+    },
+    "encryption_details": {
+      "caption": "Encryption Details",
+      "description": "The encryption details of a file or other content. See specific usage.",
+      "type": "encryption_details"
     },
     "end_date": {
       "caption": "End Date",
@@ -403,6 +413,11 @@
       "description": "Indicates logon is from a device not seen before or a first time account logon.",
       "type": "boolean_t"
     },
+    "is_renewable": {
+      "caption": "Renewable",
+      "description": "The indication of whether something is renewable. See specific usage.",
+      "type": "boolean_t"
+    },
     "is_vpn": {
       "caption": "VPN Session",
       "description": "The indication of whether the session is a VPN session.",
@@ -412,6 +427,21 @@
       "caption": "Time-based One-time Password (TOTP)",
       "description": "Whether the authentication factor is a Time-based One-time Password (TOTP).",
       "type": "boolean_t"
+    },
+    "kerberos_flags": {
+      "caption": "Kerberos Flags",
+      "description": "A bitmask, either in hexadecimal or decimal form, which encodes various attributes or permissions associated with a Kerberos ticket. These flags delineate specific characteristics of the ticket, such as its renewability or forwardability.",
+      "references": [
+        {
+          "description": "RFC 4120: 5.2.8.  KerberosFlags",
+          "url": "https://www.rfc-editor.org/rfc/rfc4120#section-5.2.8"
+        },
+        {
+          "description": "Microsoft Windows Security 4769 (see 'Ticket Options')",
+          "url": "https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/event-4769"
+        }
+      ],
+      "type": "string_t"
     },
     "kill_chain": {
       "caption": "Kill Chain",

--- a/events/audit/authentication.json
+++ b/events/audit/authentication.json
@@ -37,6 +37,25 @@
       "group": "context",
       "requirement": "optional"
     },
+    "authentication_token": {
+      "description": "The authentication token, ticket, or assertion, e.g. <code>Kerberos</code>, <code>OIDC</code>, <code>SAML</code>.",
+      "group": "context",
+      "references": [
+        {
+          "description": "RFC 4120: The Kerberos Network Authentication Service (V5)",
+          "url": "https://www.rfc-editor.org/rfc/rfc4120"
+        },
+        {
+          "description": "OpenID Connect Core 1.0",
+          "url": "https://openid.net/specs/openid-connect-core-1_0.html"
+        },
+        {
+          "description": "The OASIS Security Assertion Markup Language (SAML) V2.0",
+          "url": "https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf"
+        }
+      ],
+      "requirement": "optional"
+    },
     "dst_endpoint": {
       "description": "The endpoint to which the authentication was targeted.",
       "group": "primary",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "uid": 1
 }

--- a/objects/authentication_token.json
+++ b/objects/authentication_token.json
@@ -1,0 +1,64 @@
+{
+  "caption": "Authentication Token",
+  "description": "The Authentication Token object contains the attributes pertaining to an authentication token, ticket, or assertion e.g. Kerberos, OIDC, SAML.",
+  "extends": "object",
+  "name": "authentication_token",
+  "attributes": {
+    "created_time": {
+      "description": "The time that the authentication token was created.",
+      "requirement": "recommended"
+    },
+    "encryption_details": {
+      "description": "The encryption details of the authentication token.",
+      "requirement": "recommended"
+    },
+    "expiration_time": {
+      "description": "The expiration time of the authentication token.",
+      "requirement": "optional"
+    },
+    "is_renewable": {
+      "description": "Indicates whether the authentication token is renewable.",
+      "requirement": "optional"
+    },
+    "kerberos_flags": {
+      "requirement": "recommended"
+    },
+    "type": {
+      "description": "The type of the authentication token.",
+      "requirement": "recommended"
+    },
+    "type_id": {
+      "description": "The normalized authentication token type identifier.",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The Authentication token type is unknown."
+        },
+        "1": {
+          "caption": "Ticket Granting Ticket",
+          "description": "Ticket Granting Ticket (TGT) for Kerberos."
+        },
+        "2": {
+          "caption": "Service Ticket",
+          "description": "Service Ticket (ST) for Kerberos."
+        },
+        "3": {
+          "caption": "Identity Token",
+          "description": "Identity (ID) Token for OIDC."
+        },
+        "4": {
+          "caption": "Refresh Token",
+          "description": "Refresh Token for OIDC."
+        },
+        "5": {
+          "caption": "SAML Assertion",
+          "description": "Authentication Assertion for SAML."
+        },
+        "99": {
+          "caption": "Other"
+        }
+      },
+      "requirement": "recommended"
+    }
+  }
+}

--- a/objects/encryption_details.json
+++ b/objects/encryption_details.json
@@ -1,0 +1,58 @@
+{
+  "caption": "Encryption Details",
+  "description": "Details about the encrytpion methodology utilized.",
+  "extends": "object",
+  "name": "encryption_details",
+  "attributes": {
+    "algorithm": {
+      "caption": "Encryption Algorithm",
+      "description": "The encryption algorithm used, normalized to the caption of 'algorithm_id",
+      "requirement": "optional"
+    },
+    "algorithm_id": {
+      "caption": "Encryption Algorithm ID",
+      "description": "The encryption algorithm used.",
+      "enum": {
+        "1": {
+          "caption": "DES",
+          "description": "Data Encryption Standard Algorithm"
+        },
+        "2": {
+          "caption": "TripleDES",
+          "description": "Triple Data Encryption Standard Algorithm"
+        },
+        "3": {
+          "caption": "AES",
+          "description": "Advanced Encryption Standard Algorithm."
+        },
+        "4": {
+          "caption": "RSA",
+          "description": "Rivest-Shamir-Adleman Algorithm"
+        },
+        "5": {
+          "caption": "ECC",
+          "description": "Elliptic Curve Cryptography Algorithm"
+        },
+        "6": {
+          "caption": "SM2",
+          "description": "ShangMi Cryptographic Algorithm"
+        }
+      },
+      "requirement": "recommended"
+    },
+    "key_length": {
+      "caption": "Encryption Key Length",
+      "description": "The length of the encryption key used.",
+      "requirement": "optional"
+    },
+    "key_uid": {
+      "description": "The unique identifier of the key used for encrpytion. For example, AWS KMS Key ARN.",
+      "requirement": "optional"
+    },
+    "type": {
+      "caption": "Encryption Type",
+      "description": "The type of the encryption used.",
+      "requirement": "recommended"
+    }
+  }
+}


### PR DESCRIPTION
For additional Kerberos field mapping. This PR:

1. Adds the `authentication_token` object, which is part of OCSF `1.5.0`. Ref: [ocsf-schema/pull/1391](https://github.com/ocsf/ocsf-schema/pull/1391).
2. Adds the `encryption_details` object, which is a prerequisite for the `authentication_token` object.
3. Adds the necessary dictionary attributes.
4. Updates the extension version.

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/cce34405-baca-415f-91fa-3b1ef96b38a2" />
