### PR TITLE
SESA-1512 Add `key_uid` and Resolve Typos

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -443,6 +443,11 @@
       ],
       "type": "string_t"
     },
+    "key_uid": {
+      "caption": "Key UID",
+      "description": "The unique identifier of the key. See specific usage.",
+      "type": "string_t"
+    },
     "kill_chain": {
       "caption": "Kill Chain",
       "description": "The <a target='_blank' href='https://www.lockheedmartin.com/en-us/capabilities/cyber/cyber-kill-chain.html'>Cyber Kill Chain®</a>.",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.13.4",
+  "version": "1.14.1",
   "uid": 1
 }

--- a/objects/encryption_details.json
+++ b/objects/encryption_details.json
@@ -1,6 +1,6 @@
 {
   "caption": "Encryption Details",
-  "description": "Details about the encrytpion methodology utilized.",
+  "description": "Details about the encryption methodology utilized.",
   "extends": "object",
   "name": "encryption_details",
   "attributes": {
@@ -46,7 +46,7 @@
       "requirement": "optional"
     },
     "key_uid": {
-      "description": "The unique identifier of the key used for encrpytion. For example, AWS KMS Key ARN.",
+      "description": "The unique identifier of the key used for encryption. For example, AWS KMS Key ARN.",
       "requirement": "optional"
     },
     "type": {


### PR DESCRIPTION
### **This PR:**
- Adds the missing `key_uid` attribute to the Splunk extension dictionary
- Corrects two typos for `encryption` within the `encryption_details` object.

### **Before:**
- The `Authentication` class JSON Schema would not export, returning a 500 Internal Server error:

```
 > A failure occurred while executing de.undercouch.gradle.tasks.download.internal.DefaultWorkerExecutorHelper$DefaultWorkAction
      > de.undercouch.gradle.tasks.download.org.apache.hc.client5.http.ClientProtocolException: Internal Server Error (HTTP status code: 500, URL: http://localhost:8000/schema/classes/authentication?profiles=host,splunk%2Fba&package_name=com.splunk.ocsf.schema)
   > A failure occurred while executing de.undercouch.gradle.tasks.download.internal.DefaultWorkerExecutorHelper$DefaultWorkAction
      > de.undercouch.gradle.tasks.download.org.apache.hc.client5.http.ClientProtocolException: Internal Server Error (HTTP status code: 500, URL: http://localhost:8000/schema/classes/authentication?profiles=cloud,host,splunk%2Fba&package_name=com.splunk.ocsf.schema)
```

### **After:**
- The `Authentication` class JSON Schema now exports as expected:

<img width="757" alt="image" src="https://github.com/user-attachments/assets/e755aa75-2fcd-4c0b-81a5-e0a35796561f" />
