### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default Owners for everything in the repo
+*  @rmouritzen-splunk @Aniak5 @mikeradka @cmcginley-splunk @xqi-splunk


### PR DESCRIPTION
This PR adds a CODEOWNERS file. This will be useful with more folks reviewing changes to the Splunk extension.