### PR TITLE
SESA-1503 Add new rdp activities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Mac
+.DS_Store

--- a/events/network/email_activity.json
+++ b/events/network/email_activity.json
@@ -6,7 +6,6 @@
   ],
   "attributes": {
     "activity_id": {
-      "requirement": "required",
       "enum": {
         "1": {
           "caption": "Send"

--- a/events/network/rdp.json
+++ b/events/network/rdp.json
@@ -1,0 +1,106 @@
+{
+  "uid": 5,
+  "caption": "RDP Activity",
+  "description": "Remote Desktop Protocol (RDP) Activity events report post-authentication remote client connections between clients and servers over the network.",
+  "extends": "rdp_activity",
+  "name": "rdp_activity",
+  "profiles": [
+    "splunk/ba"
+  ],
+  "attributes": {
+    "activity_id": {
+      "enum": {
+        "1": {
+          "caption": "Initial Request",
+          "description": "The initial RDP request."
+        },
+        "2": {
+          "caption": "Initial Response",
+          "description": "The initial RDP response."
+        },
+        "3": {
+          "caption": "Connect Request",
+          "description": "An RDP connection request."
+        },
+        "4": {
+          "caption": "Connect Response",
+          "description": "An RDP connection response."
+        },
+        "5": {
+          "caption": "TLS Handshake",
+          "description": "The TLS handshake."
+        },
+        "6": {
+          "caption": "Traffic",
+          "description": "Network traffic report."
+        },
+        "7": {
+          "caption": "Disconnect",
+          "description": "An RDP connection disconnect."
+        },
+        "8": {
+          "caption": "Reconnect",
+          "description": "An RDP connection reconnect."
+        }
+      },
+      "references": [
+        {
+          "url": "https://docs.suricata.io/en/latest/output/eve/eve-json-format.html#event-type-rdp",
+          "description": "Suricata Event Type: RDP"
+        }
+      ]
+    },
+    "capabilities": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "certificate_chain": {
+      "description": "The list of observed certificates in an RDP TLS connection.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "connection_info": {
+      "description": "The remote desktop connection details, either connection-based or connectionless.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "device": {
+      "description": "The device instigating the RDP connection.",
+      "requirement": "optional",
+      "profile": null
+    },
+    "file": {
+      "description": "The file that is the target of the RDP activity.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "identifier_cookie": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "keyboard_info": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "protocol_ver": {
+      "caption": "RDP Version",
+      "description": "The Remote Desktop Protocol version.",
+      "group": "context",
+      "requirement": "recommended"
+    },
+    "remote_display": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "request": {
+      "description": "The client request in an RDP network connection.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "response": {
+      "description": "The server response in an RDP network connection.",
+      "group": "primary",
+      "requirement": "recommended"
+    }
+  }
+}


### PR DESCRIPTION
Port the RDP Activity class, which has additional activity_id's, into the rc2 Splunk extension.

<img width="1226" alt="image" src="https://github.com/user-attachments/assets/d42a44da-6d3b-45d3-b909-1bd3b38a01ee" />

See https://github.com/ocsf/ocsf-schema/pull/1415 for more details

Verified that the JSON Schema exports.