### PR TITLE
Port the 1.5 connection_info attributes

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -85,6 +85,18 @@
       "description": "The client interface. See specific usage.",
       "type": "network_interface"
     },
+    "community_uid": {
+      "caption": "Community ID",
+      "description": "The Community ID of the network connection.",
+      "source": "community_id",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "Community ID definition.",
+          "url": "https://github.com/corelight/community-id-spec"
+        }
+      ]
+    },
     "confidence_score": {
       "caption": "Confidence Score",
       "description": "The confidence score as reported by the event source.",
@@ -309,6 +321,17 @@
       "caption": "Finding Information",
       "description": "Describes the supporting information about a generated finding.",
       "type": "finding_info"
+    },
+    "flag_history": {
+      "caption": "Connection Flag History",
+      "description": "The Connection Flag History summarizes events in a network connection. For example flags <code> ShAD </code> representing SYN, SYN/ACK, ACK and Data exchange.",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "Zeek History",
+          "url": "https://docs.zeek.org/en/master/scripts/base/protocols/conn/main.zeek.html#detailed-interface:~:text=Records%20the%20state%20history%20of%20connections%20as%20a%20string%20of%20letters.%20The%20meaning%20of%20those%20letters%20is"
+        }
+      ]
     },
     "forward_addr": {
       "caption": "Forwarding Address",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "uid": 1
 }

--- a/objects/network_connection_info_ex.json
+++ b/objects/network_connection_info_ex.json
@@ -1,0 +1,79 @@
+{
+  "description": "The extended/enriched network_connection_info object.",
+  "extends": "network_connection_info",
+  "attributes": {
+    "boundary": {
+      "requirement": "optional"
+    },
+    "boundary_id": {
+      "requirement": "recommended"
+    },
+    "community_uid": {
+      "requirement": "optional"
+    },
+    "direction": {
+      "requirement": "optional"
+    },
+    "direction_id": {
+      "requirement": "required"
+    },
+    "flag_history": {
+      "requirement": "optional"
+    },
+    "protocol_name": {
+      "caption": "Protocol Name",
+      "description": "The IP protocol name in lowercase, as defined by the Internet Assigned Numbers Authority (IANA). For example: <code>tcp</code> or <code>udp</code>.",
+      "references": [
+        {
+          "description": "IANA Protocol Numbers",
+          "url": "https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml"
+        }
+      ],
+      "requirement": "recommended"
+    },
+    "protocol_num": {
+      "requirement": "recommended"
+    },
+    "protocol_ver": {
+      "caption": "IP Version",
+      "description": "The Internet Protocol version.",
+      "requirement": "optional"
+    },
+    "protocol_ver_id": {
+      "caption": "IP Version ID",
+      "description": "The Internet Protocol version identifier.",
+      "enum": {
+        "0": {
+          "caption": "Unknown"
+        },
+        "4": {
+          "caption": "Internet Protocol version 4 (IPv4)"
+        },
+        "6": {
+          "caption": "Internet Protocol version 6 (IPv6)"
+        },
+        "99": {
+          "caption": "Other"
+        }
+      },
+      "requirement": "recommended"
+    },
+    "session": {
+      "requirement": "optional"
+    },
+    "tcp_flags": {
+      "requirement": "optional"
+    },
+    "uid": {
+      "caption": "Connection UID",
+      "description": "The unique identifier of the connection.",
+      "requirement": "recommended"
+    }
+  },
+  "references": [
+    {
+      "description": "D3FEND™ Ontology d3f:NetworkSession",
+      "url": "https://d3fend.mitre.org/dao/artifact/d3f:NetworkSession/"
+    }
+  ]
+}


### PR DESCRIPTION
This PR ports the `1.5.0` attributes for the `network_connection_info` object that are missing from `rc2`.

- `community_uid` and `flag_history` added to the extension dictionary.
- verified the `network_connection_info` object JSON Schema exports without error.
- verified the `RDP Activity` class JSON Schema exports without error.