### PR TITLE
Port the 1.5.0 session object attributes

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -237,6 +237,11 @@
       "description": "The Event ID or Code that the product uses to describe the event.",
       "type": "string_t"
     },
+    "expiration_reason": {
+      "caption": "Expiration Reason",
+      "description": "The expiration reason. See specific usage.",
+      "type": "string_t"
+    },
     "evidence": {
       "caption": "Evidence",
       "description": "The data the detection exposes to the analyst.",
@@ -429,6 +434,11 @@
     "is_hotp": {
       "caption": "HMAC-based One-time Password (HOTP)",
       "description": "Whether the authentication factor is an HMAC-based One-time Password (HOTP).",
+      "type": "boolean_t"
+    },
+    "is_mfa": {
+      "caption": "Multi Factor Authentication",
+      "description": "Indicates whether Multi Factor Authentication was used during authentication.",
       "type": "boolean_t"
     },
     "is_new_logon": {
@@ -842,6 +852,11 @@
       "caption": "Target",
       "description": "The desired entity towards which the action is directed. Its values are derived via business logic. This usually represents the inferred destination entity for a logon.",
       "type": "inference"
+    },
+    "terminal": {
+      "caption": "Terminal",
+      "description": "The Pseudo Terminal. Ex: the tty or pts value.",
+      "type": "string_t"
     },
     "time": {
       "caption": "Event Time",

--- a/events/audit/authentication.json
+++ b/events/audit/authentication.json
@@ -61,6 +61,18 @@
       "group": "primary",
       "requirement": "recommended"
     },
+    "mfa": {
+      "group": "primary",
+      "requirement": "recommended",
+      "@deprecated": {
+        "message": "Use the <code>is_mfa</code> attribute instead.",
+        "since": "1.0.0"
+      }
+    },
+    "is_mfa": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
     "is_new_logon": {
       "group": "context",
       "requirement": "optional"

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "uid": 1
 }

--- a/objects/session_ex.json
+++ b/objects/session_ex.json
@@ -2,12 +2,43 @@
   "description": "The extended/enriched session object.",
   "extends": "session",
   "attributes": {
+    "count": {
+      "description": "The number of identical sessions spawned from the same source IP, destination IP, application, and content/threat type seen over a period of time.",
+      "requirement": "optional"
+    },
+    "expiration_reason": {
+      "description": "The reason which triggered the session expiration.",
+      "requirement": "optional"
+    },
+    "mfa": {
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Use the <code>is_mfa</code> attribute instead.",
+        "since": "1.0.0"
+      }
+    },
+    "is_mfa": {
+      "requirement": "optional"
+    },
+    "is_remote": {
+      "requirement": "recommended"
+    },
     "is_vpn": {
+      "requirement": "optional"
+    },
+    "terminal": {
+      "description": "The Pseudo Terminal associated with the session. Ex: the tty or pts value.",
       "requirement": "optional"
     },
     "uid_alt": {
       "description": "The alternate unique identifier of the session. e.g. AWS ARN - <code>arn:aws:sts::123344444444:assumed-role/Admin/example-session</code>.",
       "requirement": "optional"
     }
-  }
+  },
+  "references": [
+    {
+      "description": "D3FEND™ Ontology d3f:Session",
+      "url": "https://d3fend.mitre.org/dao/artifact/d3f:Session/"
+    }
+  ]
 }


### PR DESCRIPTION
This PR ports the 1.5.0 session attributes into the Splunk extension so they may be used for mappings.

- [x] Added the missing session attributes that were not in rc2.
- [x] Added the missing dictionary definitions that were not already in rc2.
- [x] Added the `mfa` deprecation. Note: could not do this by way of the dictionary due to how extension patching works.
- [x] Verified the expected attributes exist when server is loaded.
- [x] Verified the session object is consistent with 1.5.0
- [x] Verified JSON Schema exports for the `RDP Activity` and `Authentication` classes, as well as for the `session` object.
- [x] Updated the extension version.