### PR TITLE
SESA-1554_Add_attribute_associations_to_RDP_Activity

### DIFF
--- a/events/network/rdp.json
+++ b/events/network/rdp.json
@@ -102,5 +102,13 @@
       "group": "primary",
       "requirement": "recommended"
     }
+  },
+  "associations": {
+    "actor.user": [
+      "dst_endpoint"
+    ],
+    "dst_endpoint": [
+      "actor.user"
+    ]
   }
 }


### PR DESCRIPTION
Original Request: SESA-1554

For the RDP Activity class, add the following attribute associations:

```
actor.user: dst_endpoint
dst_endpoint: actor.user
```