### PR TITLE
Correct the peripheral_device.type_id enum values

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "uid": 1
 }

--- a/objects/peripheral_device_ex.json
+++ b/objects/peripheral_device_ex.json
@@ -49,15 +49,15 @@
             "caption": "Printer",
             "description": "The peripheral device is a printer."
           },
-          "7": {
+          "5": {
             "caption": "Monitor",
             "description": "The peripheral device is a monitor."
           },
-          "9": {
+          "6": {
             "caption": "Microphone",
             "description": "The peripheral device is a microphone."
           },
-          "10": {
+          "7": {
             "caption": "Webcam",
             "description": "The peripheral device is a webcam."
           },


### PR DESCRIPTION
#### Related PR:
https://github.com/ocsf/ocsf-schema/pull/1485

#### Description of changes: 
This PR corrects the order of the enum values for the `peripheral_device.type_id` which was introduced in an earlier 1.7.0-dev PR (https://github.com/ocsf/ocsf-schema/pull/1485). Without this update, the enums would be introduced to OCSF with numerical gaps.

## Before:

```json
        "7": {
          "caption": "Monitor",
          "description": "The peripheral device is a monitor."
        },
        "9": {
          "caption": "Microphone",
          "description": "The peripheral device is a microphone."
        },
        "10": {
          "caption": "Webcam",
          "description": "The peripheral device is a webcam."
```

## After:

```json
        "5": {
          "caption": "Monitor",
          "description": "The peripheral device is a monitor."
        },
        "6": {
          "caption": "Microphone",
          "description": "The peripheral device is a microphone."
        },
        "7": {
          "caption": "Webcam",
          "description": "The peripheral device is a webcam."
```

