### PR TITLE
SESA-1600 Add reporter object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -743,6 +743,11 @@
       ],
       "is_array": true
     },
+    "reporter": {
+      "caption": "Reporter",
+      "description": "The entity from which an event or finding was first reported. See specific usage.",
+      "type": "reporter"
+    },
     "risk_details": {
       "caption": "Risk Details",
       "description": "Describes the risk associated with the finding.",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "caption": "Splunk",
   "name": "splunk",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "uid": 1
 }

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -28,6 +28,10 @@
       "profile": "splunk/ba",
       "requirement": "recommended"
     },
+    "reporter": {
+      "description": "The entity from which the event or finding was first reported.",
+      "requirement": "recommended"
+    },
     "source": {
       "profile": "splunk/ba",
       "requirement": "recommended"

--- a/objects/reporter.json
+++ b/objects/reporter.json
@@ -1,0 +1,36 @@
+{
+  "caption": "Reporter",
+  "description": "The entity from which an event or finding was reported.",
+  "extends": "_entity",
+  "name": "reporter",
+  "attributes": {
+    "hostname": {
+      "description": "The hostname of the entity from which the event or finding was reported.",
+      "requirement": "recommended"
+    },
+    "ip": {
+      "description": "The IP address of the entity from which the event or finding was reported.",
+      "requirement": "recommended"
+    },
+    "name": {
+      "description": "The name of the entity from which the event or finding was reported.",
+      "requirement": "recommended"
+    },
+    "org": {
+      "description": "The organization properties of the entity that reported the event or finding.",
+      "requirement": "optional"
+    },
+    "uid": {
+      "description": "The unique identifier of the entity from which the event or finding was reported.",
+      "requirement": "recommended"
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+      "hostname",
+      "ip",
+      "name",
+      "uid"
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds the new `reporter` object from OCSF Core `1.7.0` to the Splunk extension.

- Dictionary: added `reporter` attribute.
- Objects:
  - Added the `reporter.json` object.
  - Added `reporter` to the `metadata` object.

<img width="985" height="231" alt="image" src="https://github.com/user-attachments/assets/78439242-fd47-4e02-98fb-96b40130bb99" />

<img width="1308" height="366" alt="image" src="https://github.com/user-attachments/assets/d2f80f4a-02d5-4f06-b9b8-d73192c339e7" />

Related OCSF Core PRs for reference:
- https://github.com/ocsf/ocsf-schema/pull/1476
- https://github.com/ocsf/ocsf-schema/pull/1507


Verified the expected object/fields are present and that the JSON schema exports without issues.